### PR TITLE
feat: org_admin RBAC patch

### DIFF
--- a/containers/sentry/patches/001_org_admin_rbac.patch
+++ b/containers/sentry/patches/001_org_admin_rbac.patch
@@ -1,0 +1,29 @@
+diff --git a/api/endpoints/team_projects.py b/api/endpoints/team_projects.py
+index 6624211..bd2b03c 100644
+--- a/api/endpoints/team_projects.py
++++ b/api/endpoints/team_projects.py
+@@ -48,7 +48,7 @@ class ProjectPostSerializer(serializers.Serializer):
+ class TeamProjectPermission(TeamPermission):
+     scope_map = {
+         "GET": ["project:read", "project:write", "project:admin"],
+-        "POST": ["project:write", "project:admin"],
++        "POST": ["project:admin"],
+         "PUT": ["project:write", "project:admin"],
+         "DELETE": ["project:admin"],
+     }
+diff --git a/conf/server.py b/conf/server.py
+index 19033df..00051ac 100644
+--- a/conf/server.py
++++ b/conf/server.py
+@@ -2170,11 +2170,8 @@ SENTRY_ROLES = (
+             "member:read",
+             "project:read",
+             "project:write",
+-            "project:admin",
+             "project:releases",
+             "team:read",
+-            "team:write",
+-            "team:admin",
+             "org:integrations",
+             "alerts:read",
+             "alerts:write",


### PR DESCRIPTION
Reduce permissions of org_admin, disallowing it to create projects, teams and add members to team.

Below shows what will be seen on organization setting pages by an org_admin:

## Create Project

Button is still enabled, but will fail to create

![image](https://github.com/rophy/sentry/assets/592046/014590f9-a082-412f-8c33-4380bdf2d51a)

## Create Team

Button is disabled

![image](https://github.com/rophy/sentry/assets/592046/b4d4f83a-ba1d-4376-b048-2b1ebb3d9f59)

## Adding members to team

Button still enabled, and adding member seems to work on UI, but  if you reload page, you'll see member was not actually added.

![image](https://github.com/rophy/sentry/assets/592046/e2020026-4285-4064-bd7b-905d1ef8f352)


## Removing members from team: 

Button still enabled, but will fail to remove
![image](https://github.com/rophy/sentry/assets/592046/7ff31465-d089-4c00-a2e5-f8745c92ba60)



